### PR TITLE
Update EpochToDateTimeConverter.cs

### DIFF
--- a/Sendgrid.Webhooks/Converters/EpochToDateTimeConverter.cs
+++ b/Sendgrid.Webhooks/Converters/EpochToDateTimeConverter.cs
@@ -12,7 +12,7 @@ namespace Sendgrid.Webhooks.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            base.WriteJson(writer, value, serializer);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
I need to serialize the webhook objects, but I am unable to. I cannot use XmlSerializer because there are ILists in the code which is an interface that the XmlSerializer cannot handle, and I cannot use JsonConvert because you have overridden the DateTime converter which throws a NotImplementedException when I try to serialize. 
By just calling the basic functionality for serializing DateTime instead of throwing an exception, it should work fine.
