### PR TITLE
Fix for issue #22, support for double type in the 'processed', field 'send_at'.

### DIFF
--- a/Sendgrid.Webhooks.Tests/EpochConverterTests.cs
+++ b/Sendgrid.Webhooks.Tests/EpochConverterTests.cs
@@ -38,6 +38,16 @@ namespace Sendgrid.Webhooks.Tests
         }
 
         [Test]
+        public void ReadJson_Double_ConvertsToDate()
+        {
+            var reader = new JTokenReader(new JValue((double)123.555));
+            reader.Read();
+            var result = _converter.ReadJson(reader, typeof(long), null, new JsonSerializer());
+
+            Assert.AreEqual(new DateTime(1970, 1, 1, 0, 2, 3, 555), result);
+        }
+
+        [Test]
         public void WriteJson_Date_ConvertsToEpoch()
         {
             var stringBuilder = new StringBuilder();

--- a/Sendgrid.Webhooks/Converters/EpochToDateTimeConverter.cs
+++ b/Sendgrid.Webhooks/Converters/EpochToDateTimeConverter.cs
@@ -26,8 +26,7 @@ namespace Sendgrid.Webhooks.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var timestamp = (long) reader.Value;
-
+            var timestamp = Convert.ToDouble(reader.Value);
             return EpochDate.AddSeconds(timestamp);
         }
     }


### PR DESCRIPTION
Fix for issue #22, support for double type.
Example payload:
[
  {
    "send_at": 1481050260.03746,
    "email": "test@mailinator.com",
    "smtp-id": "<removed@ismtpd0002p1iad1.sendgrid.net>",
    "timestamp": 1481050200,
    "sg_event_id": "removed",
    "sg_message_id": "removed.filter0964p1mdw1-24906-58470857-2F.0",
    "event": "processed"
  }
]