### PR TITLE
Added the "sg_machine_open" bool value to OpenEvent

### DIFF
--- a/Sendgrid.Webhooks/Events/OpenEvent.cs
+++ b/Sendgrid.Webhooks/Events/OpenEvent.cs
@@ -1,7 +1,12 @@
-﻿namespace Sendgrid.Webhooks.Events
+﻿using Newtonsoft.Json;
+using Sendgrid.Webhooks.Converters;
+
+namespace Sendgrid.Webhooks.Events
 {
     public class OpenEvent : EngagementEventBase
     {
-         
+        [JsonConverter(typeof(BooleanConverter))]
+        [JsonProperty("sg_machine_open")]
+        public bool SgMachineOpen { get; set; } = false;
     }
 }


### PR DESCRIPTION
according to this article
https://sendgrid.com/blog/apple-mail-privacy-protection/

Apple are artificially inflating opens by checking emails (opening them) on their end before allowing the user to open them. This is creating an artificially inflated open rate.

I have implemented the WebHook value "sg_machine_open" to check emails that have been opened by a bot acording to the specification here: https://docs.sendgrid.com/for-developers/tracking-events/event#sg_machine_open