### PR TITLE
Added support for .NET Standard 2.0

### DIFF
--- a/Sendgrid.Webhooks/Sendgrid.Webhooks.csproj
+++ b/Sendgrid.Webhooks/Sendgrid.Webhooks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.0;netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>

--- a/Sendgrid.Webhooks/Sendgrid.Webhooks.csproj
+++ b/Sendgrid.Webhooks/Sendgrid.Webhooks.csproj
@@ -10,7 +10,7 @@
     <!-- NuGet package -->
     <Title>Sendgrid.Webhooks</Title>
     <Description>A library to parse event webhooks from Sendgrid. Contains Parser and a set of strongly typed DTOs. It supports all available webhook events, unique arguments and categories.</Description>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.1</PackageVersion>
     <Authors>Mira Javora,Andy McCready,Brian Petersen,m0sa</Authors>
     <PackageProjectUrl>https://github.com/mirajavora/sendgrid-webhooks</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mirajavora/sendgrid-webhooks.git</RepositoryUrl>


### PR DESCRIPTION
In order to reduce the package dependency graph on more modern .NET implementations I have I have added support for .NET Standard 2.0. Because the project already works with .NET Standard 1.0 there were no additional code changes required to make it work with .NET Standard 2.0 other than adding the target framework and bumping the version number.

Targeting both .NET Standard 1.x and .NET Standard 2.0 is recommended by Microsoft in their versioning guidelines: https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0#which-net-standard-version-to-target

All tests are passing.